### PR TITLE
Go 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,7 @@
 # slogger
 
 Package `slogger` implements supporting functionality related to the
-[`exp/x/slog`](https://pkg.go.dev/golang.org/x/exp/slog) package.
-
-More specifically, it implements functionality that used to exist in `exp/x/slog`, like the
-[`NewContext`](https://pkg.go.dev/github.com/azazeal/slogger#NewContext) and
-[`FromContext`](https://pkg.go.dev/github.com/azazeal/slogger#FromContext) functions, as well as new helpers like the
-[`FromEnv`](https://pkg.go.dev/github.com/azazeal/slogger#FromEnv) function.
+[`log/slog`](https://pkg.go.dev/golang.org/log/slog) package.
 
 For more details, you may review the package documentation [here](https://pkg.go.dev/github.com/azazeal/slogger).
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/azazeal/slogger
 
-go 1.20
-
-require golang.org/x/exp v0.0.0-20230905200255-921286631fa9
+go 1.21
 
 retract v0.0.0-20230322163611-c05651b9ef2a // Published accidentally.

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,0 @@
-golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
-golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=

--- a/slogger.go
+++ b/slogger.go
@@ -4,10 +4,9 @@ package slogger
 import (
 	"context"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
-
-	"golang.org/x/exp/slog"
 )
 
 type contextKey struct{}

--- a/slogger_test.go
+++ b/slogger_test.go
@@ -3,10 +3,9 @@ package slogger
 import (
 	"context"
 	"io"
+	"log/slog"
 	"strconv"
 	"testing"
-
-	"golang.org/x/exp/slog"
 )
 
 func TestFromContext(t *testing.T) {


### PR DESCRIPTION
This PR refactors the code so that it supports the `log/slog` package of the standard library (instead of `golang.org/x/exp/slog`), from Go 1.21 onwards.